### PR TITLE
feat: add HEADLESS env var, per-session override, and MCP_BACKEND_ARGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ playwright-parallel-mcp
 
 | Tool | Description |
 |------|-------------|
-| `create_session` | Create a new isolated browser session |
+| `create_session` | Create a new isolated browser session. Accepts optional `headless` (boolean) to override the default |
 | `close_session` | Close a browser session and terminate its backend process |
 | `list_sessions` | List all active sessions |
 
@@ -218,6 +218,24 @@ Any npm package that provides an MCP server can be used:
 }
 ```
 
+### Headed Mode (Visible Browser)
+
+By default, the Playwright backend runs in headless mode. To see the browser window:
+
+```json
+{
+  "mcpServers": {
+    "playwright-parallel": {
+      "command": "npx",
+      "args": ["playwright-parallel-mcp"],
+      "env": {
+        "HEADLESS": "false"
+      }
+    }
+  }
+}
+```
+
 ## Environment Variables
 
 | Variable | Default | Description |
@@ -225,6 +243,8 @@ Any npm package that provides an MCP server can be used:
 | `MCP_BACKEND` | `playwright` | Backend MCP server: `playwright`, `chrome-devtools`, or any npm package |
 | `MAX_SESSIONS` | 10 | Maximum number of concurrent browser sessions |
 | `SESSION_TIMEOUT_MS` | 3600000 | Session inactivity timeout (1 hour) |
+| `HEADLESS` | `true` | Run Playwright browser in headless mode. Set to `false` for headed mode |
+| `MCP_BACKEND_ARGS` | _(none)_ | Additional space-separated arguments to pass to the backend MCP server |
 
 ## Comparison
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,11 +17,14 @@ server.tool(
   {
     backend: z.string().optional().describe(
       `Backend MCP server to use. Options: ${Object.keys(DEFAULT_BACKENDS).join(", ")} or any npm package name`
+    ),
+    headless: z.boolean().optional().describe(
+      "Run browser in headless mode (no visible window). Defaults to true. Set to false for visual debugging."
     )
   },
-  async ({ backend }) => {
+  async ({ backend, headless }) => {
     try {
-      const session = await sessionManager.createSession({ backend });
+      const session = await sessionManager.createSession({ backend, headless });
       return {
         content: [{
           type: "text",
@@ -221,8 +224,9 @@ async function main() {
   // 3つのセッション管理ツール + バックエンドツール
   const totalTools = 3 + toolCount;
 
+  const headless = process.env.HEADLESS !== "false";
   console.error(`playwright-parallel-mcp server started`);
-  console.error(`  Backend: ${backend}`);
+  console.error(`  Backend: ${backend}${backend === "playwright" ? (headless ? " (headless)" : " (headed)") : ""}`);
   console.error(`  Tools: ${totalTools} (3 session + ${toolCount} backend)`);
 
   const transport = new StdioServerTransport();

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -17,6 +17,7 @@ export interface Session {
 
 export interface CreateSessionOptions {
   backend?: string;  // "playwright" | "chrome-devtools" | カスタムコマンド
+  headless?: boolean; // Override headless mode for this session
 }
 
 /**
@@ -30,6 +31,8 @@ class SessionManager {
   private sessionTimeout = parseInt(process.env.SESSION_TIMEOUT_MS || "3600000", 10);
   private cachedTools: McpTool[] | null = null;
   private defaultBackend = process.env.MCP_BACKEND || "playwright";
+  private headless = process.env.HEADLESS !== "false";
+  private backendArgs = process.env.MCP_BACKEND_ARGS?.split(" ").filter(Boolean) || [];
 
   constructor() {
     this.startCleanupInterval();
@@ -102,25 +105,40 @@ class SessionManager {
   /**
    * バックエンド設定を取得
    */
-  private getBackendConfig(backend: string): BackendConfig {
+  private getBackendConfig(backend: string, headlessOverride?: boolean): BackendConfig {
+    let config: BackendConfig;
+
     // プリセットバックエンドを確認
     if (DEFAULT_BACKENDS[backend]) {
-      return DEFAULT_BACKENDS[backend];
+      config = { ...DEFAULT_BACKENDS[backend], args: [...DEFAULT_BACKENDS[backend].args] };
+    } else {
+      // カスタムバックエンドはnpx経由でのみ実行可能
+      // セキュリティ: パッケージ名のバリデーションでコマンドインジェクションを防止
+      if (!this.isValidPackageName(backend)) {
+        throw new Error(
+          `Invalid backend package name: "${backend}". ` +
+          `Use a valid npm package name or one of: ${Object.keys(DEFAULT_BACKENDS).join(", ")}`
+        );
+      }
+
+      config = {
+        command: "npx",
+        args: [`${backend}@latest`]
+      };
     }
 
-    // カスタムバックエンドはnpx経由でのみ実行可能
-    // セキュリティ: パッケージ名のバリデーションでコマンドインジェクションを防止
-    if (!this.isValidPackageName(backend)) {
-      throw new Error(
-        `Invalid backend package name: "${backend}". ` +
-        `Use a valid npm package name or one of: ${Object.keys(DEFAULT_BACKENDS).join(", ")}`
-      );
+    // Append --headless for playwright backend (per-session override > env var)
+    const useHeadless = headlessOverride ?? this.headless;
+    if (backend === "playwright" && useHeadless) {
+      config.args.push("--headless");
     }
 
-    return {
-      command: "npx",
-      args: [`${backend}@latest`]
-    };
+    // Append any extra backend args from MCP_BACKEND_ARGS
+    if (this.backendArgs.length > 0) {
+      config.args.push(...this.backendArgs);
+    }
+
+    return config;
   }
 
   /**
@@ -158,7 +176,7 @@ class SessionManager {
       }
 
       const backend = options.backend ?? this.defaultBackend;
-      const config = this.getBackendConfig(backend);
+      const config = this.getBackendConfig(backend, options.headless);
       const client = new McpClient(config);
 
       await client.start();


### PR DESCRIPTION
Adds three features for browser mode configuration:

- **`HEADLESS` env var** (default `true`): runs Playwright headless by default. Set `HEADLESS=false` for headed mode.
- **Per-session `headless` param** on `create_session`: override the default per session.
- **`MCP_BACKEND_ARGS` env var**: pass extra args to the backend MCP server.

All 12 e2e tests pass (default headless, explicit headless=true, explicit headless=false, session lifecycle).